### PR TITLE
Added LoadBalancer Encryption

### DIFF
--- a/kyverno/EKS/load-balancer-encryption.yaml
+++ b/kyverno/EKS/load-balancer-encryption.yaml
@@ -1,0 +1,36 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: loadbalancer-use-ssl-cert
+  annotations:
+    policies.kyverno.io/title: Require Encryption with AWS LoadBalancers
+    policies.kyverno.io/category: AWS, EKS Best Practices
+    policies.kyverno.io/severity: medium
+    policies.kyverno.io/subject: Service
+    kyverno.io/kyverno-version: 1.7.3, 1.8.0-rc2
+    policies.kyverno.io/minversion: 1.6.0
+    kyverno.io/kubernetes-version: "1.23-1.24"
+    policies.kyverno.io/description: >-
+      Services of type LoadBalancer when deployed inside AWS have support for
+      transport encryption if it is enabled via an annotation. This policy requires
+      that Services of type LoadBalancer contain the annotation
+      service.beta.kubernetes.io/aws-load-balancer-ssl-cert with some value.
+spec:
+  validationFailureAction: enforce #audit
+  background: true
+  rules:
+  - name: Require Encryption with AWS LoadBalancers
+    match:
+      any:
+      - resources:
+          kinds:
+          - Service
+  validate:
+    message:
+    pattern:
+      metadata:
+        annotations:
+          service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "?*"
+      (spec):
+        (type): LoadBalancer
+  


### PR DESCRIPTION
Added LoadBalancer Encryption:

In AWS EKS when you create a service type ==> LoadBalancer
use SSL Cert for that until and unless it wont create a loadbalancer, throws a violation error